### PR TITLE
Update GH Action for Detached Head

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       # Action setup
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref_name }}
       - uses: actions/setup-node@v3
         with:
           node-version: '18.x'
@@ -57,4 +59,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git push origin
+          git push


### PR DESCRIPTION
The previous run of the action encountered a new error with a detached head when committing and pushing changes to the `package.json`. Based on this [discussion](https://github.com/actions/checkout/issues/317#issuecomment-1221335371), the workflow run needed to have its [Github context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) specified, in this case the tag name. 