### PR TITLE
Create CI for Building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build Package
 
-# Run this workflow whenever there's a PR that is opened, synchronized, and repored
+# Run this workflow whenever there's a PR that is opened, synchronized, and reopened
 on: pull_request
 
 jobs:


### PR DESCRIPTION
This PR adds a Github Action that will run our storybook and library build scripts, to tell if we're going to have a build error before hitting production. 