### PR TITLE
Explicitly mention which PR types run action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
 name: Build Package
 
 # Run this workflow whenever there's a PR that is opened, synchronized, and reopened
-on: pull_request
+on: 
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   # Label for build job


### PR DESCRIPTION
The build action wasn't running as intended, so added the explicit types to trigger the action on a PR.